### PR TITLE
Make delete attachment link text red

### DIFF
--- a/app/views/admin/attachments/_attachments.html.erb
+++ b/app/views/admin/attachments/_attachments.html.erb
@@ -31,7 +31,7 @@
         text: link_to('Edit', [:edit, :admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], class: "govuk-link govuk-link--no-visited-state")
       },
       {
-        text: link_to("Delete", [:confirm_destroy, :admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], class: "govuk-link govuk-link--no-visited-state")
+        text: link_to("Delete", [:confirm_destroy, :admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], class: "govuk-link govuk-link--no-visited-state gem-link--destructive")
       }
     ]
   end


### PR DESCRIPTION
This makes it consistent with the rest of the application.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
