### PR TITLE
831 introduce cancel button viewcomponent for govuk design system pages

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,3 +39,7 @@ Rails/LexicallyScopedActionFilter:
 Style/OptionalBooleanParameter:
   Exclude:
     - 'app/workers/*.rb'
+
+Lint/MissingSuper:
+  Exclude:
+    - 'app/components/*/*.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem "sprockets-rails"
 gem "transitions", require: ["transitions", "active_record/transitions"]
 gem "uglifier"
 gem "validates_email_format_of"
+gem "view_component"
 gem "whenever", require: false
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -717,6 +717,10 @@ GEM
     validates_email_format_of (1.7.2)
       i18n
     version_gem (1.1.0)
+    view_component (2.71.0)
+      activesupport (>= 5.0.0, < 8.0)
+      concurrent-ruby (~> 1.0)
+      method_source (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     warden-oauth2 (0.0.1)
@@ -828,6 +832,7 @@ DEPENDENCIES
   transitions
   uglifier
   validates_email_format_of
+  view_component
   webmock
   whenever
 

--- a/app/components/admin/form_cancel_component.html.erb
+++ b/app/components/admin/form_cancel_component.html.erb
@@ -1,0 +1,1 @@
+<a class="govuk-link" href="<%= path %>">Cancel</a>

--- a/app/components/admin/form_cancel_component.rb
+++ b/app/components/admin/form_cancel_component.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Admin::FormCancelComponent < ViewComponent::Base
+
+  def initialize(object:)
+    @url_maker = Whitehall::UrlMaker.new(host: Plek.find("whitehall"))
+    @object = object
+  end
+
+private
+
+  def path
+    if @object.new_record?
+      case @object
+      when CorporateInformationPage
+        @url_maker.polymorphic_path([:admin, @object.owning_organisation, CorporateInformationPage])
+      when Edition
+        @url_maker.admin_editions_path
+      else
+        @url_maker.polymorphic_path([:admin, @object.class])
+      end
+    else
+      case @object
+      when CorporateInformationPage, Edition
+        @url_maker.admin_edition_path(@object)
+      else
+        @url_maker.polymorphic_path([:admin, object])
+      end
+    end
+  end
+end

--- a/test/components/admin/form_cancel_component_test.rb
+++ b/test/components/admin/form_cancel_component_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::FormCancelComponentTest < ViewComponent::TestCase
+  def test_component_renders_something_useful
+    # assert_equal(
+    #   %(<span>Hello, components!</span>),
+    #   render_inline(Admin::FormCancelComponent.new(message: "Hello, components!")).css("span").to_html
+    # )
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
