### PR TITLE
Adding logs to show govuk request id in background workers

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -19,6 +19,7 @@ class Admin::AttachmentsController < Admin::BaseController
   def new; end
 
   def create
+    logger.info "[AttachmentsController] govuk_request_id: #{GdsApi::GovukHeaders.headers[:govuk_request_id]}"
     if save_attachment
       attachment_updater(attachment.attachment_data)
       redirect_to attachable_attachments_path(attachable), notice: "Attachment '#{attachment.title}' uploaded"

--- a/app/workers/asset_manager_attachment_metadata_worker.rb
+++ b/app/workers/asset_manager_attachment_metadata_worker.rb
@@ -4,6 +4,7 @@ class AssetManagerAttachmentMetadataWorker < WorkerBase
   def perform(attachment_data_id)
     attachment_data = AttachmentData.find(attachment_data_id)
     return unless attachment_data.present? && attachment_data.uploaded_to_asset_manager_at
+    logger.info "[AssetManagerAttachmentMetadataWorker] govuk_request_id: #{GdsApi::GovukHeaders.headers[:govuk_request_id]} attachment_data_id: #{attachment_data_id}"
 
     AssetManager::AttachmentUpdater.call(
       attachment_data,

--- a/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
+++ b/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
@@ -4,6 +4,7 @@ class AssetManagerAttachmentRedirectUrlUpdateWorker < WorkerBase
   def perform(attachment_data_id)
     attachment_data = AttachmentData.find_by(id: attachment_data_id)
     return if attachment_data.blank?
+    logger.info "[AssetManagerAttachmentRedirectUrlUpdateWorker]  govuk_request_id: #{GdsApi::GovukHeaders.headers[:govuk_request_id]} attachment_data_id: #{attachment_data_id}"
 
     AssetManager::AttachmentUpdater.call(attachment_data, redirect_url: true)
   end

--- a/app/workers/asset_manager_attachment_set_uploaded_to_worker.rb
+++ b/app/workers/asset_manager_attachment_set_uploaded_to_worker.rb
@@ -18,6 +18,7 @@ class AssetManagerAttachmentSetUploadedToWorker < WorkerBase
   class AttachmentDataNotFoundTransient < AttachmentDataNotFound; end
 
   def perform(model_class, model_id, legacy_url_path)
+    logger.info "[AssetManagerAttachmentSetUploadedToWorker]  govuk_request_id: #{GdsApi::GovukHeaders.headers[:govuk_request_id]} legacy_url_path: #{legacy_url_path}"
     model = model_class.constantize.find(model_id)
 
     found = false

--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -5,6 +5,7 @@ class AssetManagerCreateWhitehallAssetWorker < WorkerBase
 
   def perform(file_path, legacy_url_path, draft = false, attachable_model_class = nil, attachable_model_id = nil, auth_bypass_ids = [])
     return unless File.exist?(file_path)
+    logger.info "[AssetManagerCreateWhitehallAssetWorker] govuk_request_id: #{GdsApi::GovukHeaders.headers[:govuk_request_id]} legacy_url_path: #{legacy_url_path}"
 
     file = File.open(file_path)
     asset_options = { file:, legacy_url_path:, auth_bypass_ids: }

--- a/app/workers/asset_manager_delete_asset_worker.rb
+++ b/app/workers/asset_manager_delete_asset_worker.rb
@@ -2,6 +2,7 @@ class AssetManagerDeleteAssetWorker < WorkerBase
   sidekiq_options queue: "asset_manager"
 
   def perform(legacy_url_path)
+    logger.info "[AssetManagerDeleteAssetWorker]  govuk_request_id: #{GdsApi::GovukHeaders.headers[:govuk_request_id]} legacy_url_path: #{legacy_url_path}"
     AssetManager::AssetDeleter.call(legacy_url_path)
   end
 end

--- a/app/workers/asset_manager_update_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_update_whitehall_asset_worker.rb
@@ -6,6 +6,7 @@ class AssetManagerUpdateWhitehallAssetWorker < WorkerBase
     asset_data = GlobalID::Locator.locate(model.to_global_id)
     path = asset_data.file.asset_manager_path
     AssetManager::AssetUpdater.call(asset_data, path, attributes)
+    logger.info "[AssetManagerUpdateWhitehallAssetWorker]  govuk_request_id: #{GdsApi::GovukHeaders.headers[:govuk_request_id]} asset_manager_path: #{path}"
 
     # Update any other versions of the file (e.g. PDF thumbnail, or resized versions of an image)
     asset_versions = asset_data.file.versions.values.select(&:present?)


### PR DESCRIPTION
Current govuk request id is not passed to background workers atm. So We added logs in asset manager workers so it's easier to trace a request through logit.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
